### PR TITLE
Made a bit more friendly for python 3 

### DIFF
--- a/trustyuri/TrustyUriUtils.py
+++ b/trustyuri/TrustyUriUtils.py
@@ -6,4 +6,4 @@ def get_trustyuri_tail(s):
     return re.sub(r'^(.*[^A-Za-z0-9\-_]|)([A-Za-z0-9\-_]{25,})(\.[A-Za-z0-9\-_]{0,20})?$', r'\2', s)
 
 def get_base64(s):
-    return re.sub(r'=', '', base64.b64encode(s, '-_'))
+    return re.sub(r'=', '', base64.b64encode(s, b'-_').decode('utf-8'))

--- a/trustyuri/rdf/RdfHasher.py
+++ b/trustyuri/rdf/RdfHasher.py
@@ -3,12 +3,13 @@ from trustyuri import TrustyUriUtils
 from trustyuri.rdf.StatementComparator import StatementComparator
 from rdflib.term import URIRef
 import re
+from functools import cmp_to_key
 from trustyuri.rdf.RdfPreprocessor import preprocess
 
 def make_hash(quads, hashstr=None):
     quads = preprocess(quads, hashstr=hashstr)
     comp = StatementComparator(hashstr)
-    quads = sorted(quads, cmp=lambda q1, q2: comp.compare(q1, q2))
+    quads = sorted(quads, key=cmp_to_key(lambda q1, q2: comp.compare(q1, q2)))
     s = ""
     previous = ""
     for q in quads:

--- a/trustyuri/rdf/RdfPreprocessor.py
+++ b/trustyuri/rdf/RdfPreprocessor.py
@@ -17,5 +17,5 @@ def preprocess(quads, hashstr=None, baseuri=None):
 def transform(uri, hashstr, baseuri, bnodemap):
     if uri is None: return None
     if baseuri is None:
-        return URIRef(RdfUtils.normalize(uri, hashstr))
+        return URIRef(RdfUtils.normalize(uri, hashstr).decode('utf-8'))
     return RdfUtils.get_trustyuri(uri, baseuri, " ", bnodemap)

--- a/trustyuri/rdf/RdfUtils.py
+++ b/trustyuri/rdf/RdfUtils.py
@@ -6,6 +6,7 @@ from rdflib.util import guess_format
 def get_trustyuri_str(baseuri, hashstr, suffix=None):
     s = expand_baseuri(baseuri) + hashstr
     if not suffix is None:
+        suffix = suffix.decode('utf-8')
         if suffix.startswith("_"):
             # Make two underscores, as one underscore is reserved for blank nodes
             s = s + "#_" + suffix
@@ -46,7 +47,7 @@ def get_bnode_number(bnode, bnodemap):
     return bnodemap[i]
 
 def expand_baseuri(baseuri):
-    s = get_str(baseuri)
+    s = get_str(baseuri).decode('utf-8')
     if re.match(r'.*[A-Za-z0-9\-_]', s): s = s + "."
     return s
 


### PR DESCRIPTION
I made a few changes to support python 3 better, mostly regarding strings as they often need decoding from bytes to utf-8. Judging from the tests the changes don't seem to break backwards compatibility for Python 2.7
